### PR TITLE
only display x axis tick mark for years present

### DIFF
--- a/src/httpdocs/css/global.css
+++ b/src/httpdocs/css/global.css
@@ -456,15 +456,11 @@ p {
   font-size: 12px;
 }
 /* line 72, ../../scss/partials/_chart.scss */
-.axis .odd {
-  fill: none;
-}
-/* line 76, ../../scss/partials/_chart.scss */
 .axis .thisYear {
   fill: black;
   font-weight: bold;
 }
-/* line 81, ../../scss/partials/_chart.scss */
+/* line 77, ../../scss/partials/_chart.scss */
 .axis text {
   cursor: default;
 }
@@ -472,35 +468,35 @@ p {
 /*
 * Layers
 */
-/* line 90, ../../scss/partials/_chart.scss */
+/* line 86, ../../scss/partials/_chart.scss */
 .multiarea {
   fill-opacity: 0.65;
 }
 
-/* line 93, ../../scss/partials/_chart.scss */
+/* line 89, ../../scss/partials/_chart.scss */
 .multiline {
   fill: none;
   stroke-width: 2px;
   opacity: 1;
 }
 
-/* line 98, ../../scss/partials/_chart.scss */
+/* line 94, ../../scss/partials/_chart.scss */
 .multiaxis path {
   stroke-width: 0;
   fill: none;
 }
 
-/* line 103, ../../scss/partials/_chart.scss */
+/* line 99, ../../scss/partials/_chart.scss */
 .multigrid .tick {
   stroke: lightgray;
   opacity: 0;
 }
-/* line 107, ../../scss/partials/_chart.scss */
+/* line 103, ../../scss/partials/_chart.scss */
 .multigrid path {
   stroke-width: 1;
 }
 
-/* line 112, ../../scss/partials/_chart.scss */
+/* line 108, ../../scss/partials/_chart.scss */
 .layerLine, .sideShadow {
   box-shadow: -3px 0px 8px black;
   margin-left: 10px;

--- a/src/httpdocs/js/chart.js
+++ b/src/httpdocs/js/chart.js
@@ -275,6 +275,7 @@ avb.chart = function () {
          */
         var xAxis = d3.svg.axis().scale(chart.xscale)
             .orient("bottom").tickSize(0, 0, 0).tickPadding(10)
+            .ticks(data.values.length)
             .tickFormat(function (d) {
                 return d;
             });
@@ -336,14 +337,6 @@ avb.chart = function () {
         chart.yAxisSocket = chart.axes.append("g")
             .attr("class", "axis")
             .attr("transform", "translate( " + chart.xmargin + ",0)").call(yAxis);
-
-        // mark odd entries
-
-        // d3 can't do odd selectors
-        $('.xAxis .tick:odd').each(function () {
-            //jquery can't add classes to SVG elements
-            d3.select(this).classed('odd', true);
-        });
 
         // highlights label that represents current year on axis
         d3.select('.xAxis g:nth-child(' + (yearIndex + 1) + ')')

--- a/src/scss/partials/_chart.scss
+++ b/src/scss/partials/_chart.scss
@@ -69,10 +69,6 @@
     font-size: 12px;
   }
 
-  .odd {
-    fill:none;
-  }
-
   .thisYear {
     fill: black;
     font-weight: bold;


### PR DESCRIPTION
some strange styling was added to odd elements in the x-axis tickmarks
for the homepage stacked area chart. Providing a fixed tick count -- the
number of years of data present displays the correct single tick marks
with no interpolated points between years. I needed to remove the
styling on the odd nodes in order for this to work. I'm not sure why
that styling was present.

<img width="604" alt="screen shot 2017-06-27 at 10 05 39 pm" src="https://user-images.githubusercontent.com/1413330/27617508-c5f7e142-5b84-11e7-8d1b-d36e9b776d69.png">

closes #3